### PR TITLE
Add script that verifies the operation count using PMU counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,11 @@ inception_v3 | 27.16 | 5.75
 </td>
 </tr>
 </p>
+
+## Verification
+
+The operation counts can be verified experimentally by using CPU PMU
+counters: see [benchmark/verify_thop.py](benchmark/verify_thop.py)
+script. This requires the ``python-papi`` package. See [blog
+post](http://www.bnikolic.co.uk/blog/python/flops/2019/10/01/pytorch-count-flops.html)
+for explanation of operation and results.

--- a/benchmark/verify_thop.py
+++ b/benchmark/verify_thop.py
@@ -1,0 +1,26 @@
+import torch
+from torchvision import models
+from thop.profile import profile
+
+from pypapi import events, papi_high as high
+
+model_names = sorted(name for name in models.__dict__ if
+                     name.islower() and not name.startswith("__") # and "inception" in name
+                     and callable(models.__dict__[name]))
+
+print("%s | %s | %s | %s" % ("Model", "Params(M)", "FLOPs(G)", "PMU-FLOPS(G)"))
+print("---|---|---|---")
+
+device = "cpu"
+torch.set_num_threads(1)
+
+for name in model_names:
+    model = models.__dict__[name]().double().to(device)
+    dsize = (1, 3, 224, 224)
+    if "inception" in name:
+        dsize = (1, 3, 299, 299)
+    inputs = torch.randn(dsize, dtype=torch.double).to(device)
+    high.start_counters([events.PAPI_DP_OPS,])
+    total_ops, total_params = profile(model, (inputs,), verbose=False)
+    flopsPMU=high.stop_counters()
+    print("%s | %.2f | %.2f | %.2f" % (name, total_params / (1000 ** 2), total_ops / (1000 ** 3), flopsPMU[0] / 1e9 / 2))


### PR DESCRIPTION
If you are interested: add a script that uses PAPI and CPU PMU counters to experimentally verify the counted FLOPs