### PR TITLE
support nn.SyncBatchNorm

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -35,6 +35,7 @@ register_hooks = {
     nn.BatchNorm1d: count_bn,
     nn.BatchNorm2d: count_bn,
     nn.BatchNorm3d: count_bn,
+    nn.SyncBatchNorm: count_bn,
 
     nn.ReLU: zero_ops,
     nn.ReLU6: zero_ops,


### PR DESCRIPTION
solve the warning: Cannot find rule for <class
'torch.nn.modules.batchnorm.SyncBatchNorm'>. Treat it as zero Macs and
zero Params.