### PR TITLE
Avoid adding nn.SyncBatchNorm hook when torch version < 1.1.0

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -35,7 +35,6 @@ register_hooks = {
     nn.BatchNorm1d: count_bn,
     nn.BatchNorm2d: count_bn,
     nn.BatchNorm3d: count_bn,
-    nn.SyncBatchNorm: count_bn,
 
     nn.ReLU: zero_ops,
     nn.ReLU6: zero_ops,
@@ -70,6 +69,10 @@ register_hooks = {
     nn.LSTM: count_lstm,
 }
 
+if LooseVersion(torch.__version__) >= LooseVersion("1.1.0"):
+    register_hooks.update({
+        nn.SyncBatchNorm: count_bn
+    })
 
 def profile_origin(model, inputs, custom_ops=None, verbose=True):
     handler_collection = []


### PR DESCRIPTION
PyTorch 1.0.0 and older versions do not support nn.SyncBatchNorm. Add the corresponding hook would cause an error. This commit only adds nn.SyncBatchNorm hook when torch.version >= 1.1.0.