### PR TITLE
fix count_adap_avgpool

### DIFF
--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -89,7 +89,7 @@ def count_avgpool(m, x, y):
 
 
 def count_adap_avgpool(m, x, y):
-    kernel = torch.DoubleTensor([*(x[0].shape[2:])]) // torch.DoubleTensor(list((m.output_size,))).squeeze()
+    kernel = torch.DoubleTensor([*(x[0].shape[2:])]) // torch.DoubleTensor([*(y.shape[2:])])
     total_add = torch.prod(kernel)
     total_div = 1
     kernel_ops = total_add + total_div


### PR DESCRIPTION
Summary:
`torch.DoubleTensor(list((m.output_size,)))` will raise error when `output_size` contains `None`.
Now, obtain the output size from `y` directly.