### PR TITLE
Update for python 3.9 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*test*
+# *test*
 *.t7
 *.pth
 # only keep the setup.py under root folder

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+from thop import utils
+import pytest
+
+class TestUtils:
+    def test_clever_format_returns_formatted_number(self):
+        nums = 1
+        format = "%.2f"
+        clever_nums = utils.clever_format(nums, format)
+        assert clever_nums == '1.00B'
+
+    def test_clever_format_returns_formatted_numbers(self):
+        nums = [1, 2]
+        format = "%.2f"
+        clever_nums = utils.clever_format(nums, format)
+        assert clever_nums == ('1.00B', '2.00B')

--- a/thop/utils.py
+++ b/thop/utils.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 
 
 def clever_format(nums, format="%.2f"):


### PR DESCRIPTION
Fixes deprecation warning.

```shell
c:\tools\anaconda3\envs\yolo\lib\site-packages\thop\utils.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Iterable
```