### PR TITLE
fix:issue#107. Ignore the `nn.Sequential`

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -67,6 +67,8 @@ register_hooks = {
     nn.RNN: count_rnn,
     nn.GRU: count_gru,
     nn.LSTM: count_lstm,
+
+    nn.Sequential: zero_ops,
 }
 
 if LooseVersion(torch.__version__) >= LooseVersion("1.1.0"):


### PR DESCRIPTION
The `Sequential` container works for cascading and itself should be ignored.