### PR TITLE
Update profile() to use deepcopy of model

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -1,3 +1,5 @@
+import copy
+
 from distutils.version import LooseVersion
 
 from thop.vision.basic_hooks import *
@@ -151,6 +153,7 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True):
 
 
 def profile(model: nn.Module, inputs, custom_ops=None, verbose=True):
+    model = copy.deepcopy(model)
     handler_collection = {}
     types_collection = set()
     if custom_ops is None:


### PR DESCRIPTION
Reloading the state_dict of a profiled model fails when the new model instance was not profiled as well. Profiling alters the model state_dict by adding buffers. Profiling a model should not change the model in any way. Maybe there is a more elegant way to to this without deepcopying (remove hooks etc.)