### PR TITLE
Return layer-wise profiling result.

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -198,7 +198,7 @@ def profile(model: nn.Module, inputs, custom_ops=None, verbose=True, ret_layer_i
             #     m_ops, m_params = dfs_count(m, prefix=prefix + "\t")
             # else:
             #     m_ops, m_params = m.total_ops, m.total_params
-            next_dict = None
+            next_dict = {}
             if m in handler_collection and not isinstance(m, (nn.Sequential, nn.ModuleList)):
                 m_ops, m_params = m.total_ops.item(), m.total_params.item()
             else:


### PR DESCRIPTION
Add support for returning macs and param count for each layer, which is a useful feature provided by PTFlops.
The layer-wise result is organized with a tree-like dict. Each node has three elements, (macs, parameter count, children dict).