### PR TITLE
Update basic_hooks.py

### DIFF
--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -112,9 +112,8 @@ def count_avgpool(m, x, y):
 
 
 def count_adap_avgpool(m, x, y):
-    kernel = torch.DoubleTensor([*(x[0].shape[2:])]) // torch.DoubleTensor(
-        [*(y.shape[2:])]
-    )
+    kernel = torch.div(torch.DoubleTensor([*(x[0].shape[2:])]), torch.DoubleTensor(
+        [*(y.shape[2:])]), rounding_mode='floor')
     total_add = torch.prod(kernel)
     num_elements = y.numel()
     m.total_ops += counter_adap_avg(total_add, num_elements)


### PR DESCRIPTION
to avoid warning message while using the operator `//` (__floordiv__) :

UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').
  kernel = torch.DoubleTensor([*(x[0].shape[2:])]) // torch.DoubleTensor(