### PR TITLE
Add onnx to avoid import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ readme = open("README.md").read()
 VERSION = "0.0.5"
 
 requirements = [
+    "onnx",
     "torch",
 ]
 


### PR DESCRIPTION
When I installed `thop` via `pip`, I could not import `thop` successfully as follows:

```
In [1]: import thop
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Input In [1], in <cell line: 1>()
----> 1 import thop

File /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.9/site-packages/thop/__init__.py:3, in <module>
      1 from .utils import clever_format
      2 from .profile import profile, profile_origin
----> 3 from .onnx_profile import OnnxProfile
      4 import torch
      6 default_dtype = torch.float64

File /opt/homebrew/Caskroom/miniconda/base/envs/optuna/lib/python3.9/site-packages/thop/onnx_profile.py:3, in <module>
      1 import torch
      2 import torch.nn
----> 3 import onnx
      4 from onnx import numpy_helper
      5 import numpy as np

ModuleNotFoundError: No module named 'onnx'
```

## Depedencies:

- thop: 0.1.0.post2206102148
- torch: 1.11.0
- Python: 3.9.12