### PR TITLE
Fix `DeprecationWarning: distutils Version classes are deprecated`

### DIFF
--- a/thop/fx_profile.py
+++ b/thop/fx_profile.py
@@ -2,9 +2,9 @@ import logging
 import torch
 import torch as th
 import torch.nn as nn
-from distutils.version import LooseVersion
+import pkg_resources as pkg
 
-if LooseVersion(torch.__version__) < LooseVersion("1.8.0"):
+if pkg.parse_version(torch.__version__) < pkg.parse_version("1.8.0"):
     logging.warning(
         f"torch.fx requires version higher than 1.8.0. "
         f"But You are using an old version PyTorch {torch.__version__}. "

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+import pkg_resources as pkg
 
 from thop.vision.basic_hooks import *
 from thop.rnn_hooks import *
@@ -9,7 +9,7 @@ from thop.rnn_hooks import *
 
 from .utils import prGreen, prRed, prYellow
 
-if LooseVersion(torch.__version__) < LooseVersion("1.0.0"):
+if pkg.parse_version(torch.__version__) < pkg.parse_version("1.0.0"):
     logging.warning(
         "You are using an old version PyTorch {version}, which THOP does NOT support.".format(
             version=torch.__version__
@@ -65,7 +65,7 @@ register_hooks = {
     nn.PixelShuffle: zero_ops,
 }
 
-if LooseVersion(torch.__version__) >= LooseVersion("1.1.0"):
+if pkg.parse_version(torch.__version__) >= pkg.parse_version("1.1.0"):
     register_hooks.update({nn.SyncBatchNorm: count_normalization})
 
 


### PR DESCRIPTION
Fixes issue #200:

https://github.com/ultralytics/ultralytics/actions/runs/4380005063/jobs/7666578652
<img width="1746" alt="Screenshot 2023-03-10 at 19 21 46" src="https://user-images.githubusercontent.com/26833433/224393867-d320c225-583e-4785-a4ee-3453381e6a8b.png">
