### PR TITLE
Upload sdist to PyPI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         if pip search thop | grep -o "\((.*)\)" | xargs python .github/workflows/date_extraction.py -m ; then
           echo "There has been more than one week since last update, start to build."
-          python setup.py bdist_wheel
+          python setup.py sdist bdist_wheel
           twine check dist/*
           twine upload dist/*
         else

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 rm -rf build/ dist/
-python setup.py bdist_wheel
+python setup.py sdist bdist_wheel
 twine check dist/*
 twine upload dist/*


### PR DESCRIPTION
I'm looking to get `thop` onto conda-forge using [grayskull](https://github.com/conda/grayskull), but that relies on an sdist being available for `thop` on PyPI (which is currently not the case).

Fixes #203.