### PR TITLE
Switched from distutils.version to pkg_resources

### DIFF
--- a/thop/fx_profile.py
+++ b/thop/fx_profile.py
@@ -2,9 +2,9 @@ import logging
 import torch
 import torch as th
 import torch.nn as nn
-from distutils.version import LooseVersion
+import pkg_resources as pkg
 
-if LooseVersion(torch.__version__) < LooseVersion("1.8.0"):
+if pkg.parse_version(torch.__version__) < pkg.parse_version("1.8.0"):
     logging.warning(
         f"torch.fx requires version higher than 1.8.0. "
         f"But You are using an old version PyTorch {torch.__version__}. "

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+import pkg_resources as pkg
 
 from thop.vision.basic_hooks import *
 from thop.rnn_hooks import *
@@ -9,7 +9,7 @@ from thop.rnn_hooks import *
 
 from .utils import prGreen, prRed, prYellow
 
-if LooseVersion(torch.__version__) < LooseVersion("1.0.0"):
+if pkg.parse_version(torch.__version__) < pkg.parse_version("1.0.0"):
     logging.warning(
         "You are using an old version PyTorch {version}, which THOP does NOT support.".format(
             version=torch.__version__
@@ -65,7 +65,7 @@ register_hooks = {
     nn.PixelShuffle: zero_ops,
 }
 
-if LooseVersion(torch.__version__) >= LooseVersion("1.1.0"):
+if pkg.parse_version(torch.__version__) >= pkg.parse_version("1.1.0"):
     register_hooks.update({nn.SyncBatchNorm: count_normalization})
 
 


### PR DESCRIPTION
This PR fixes the following deprecation warnings:

```
.venv/lib/python3.11/site-packages/thop/profile.py:12
.venv/lib/python3.11/site-packages/thop/profile.py:12
  /Users/neale/panel-quality-imager/.venv/lib/python3.11/site-packages/thop/profile.py:12: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(torch.__version__) < LooseVersion("1.0.0"):

.venv/lib/python3.11/site-packages/thop/profile.py:68
.venv/lib/python3.11/site-packages/thop/profile.py:68
  /Users/neale/panel-quality-imager/.venv/lib/python3.11/site-packages/thop/profile.py:68: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(torch.__version__) >= LooseVersion("1.1.0"):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

This appears to be the same fix from #201 that doesn't appear to be merged and is closed by that author. 